### PR TITLE
Adds documentationUrl parameter to functionality anotation

### DIFF
--- a/bennu-struts/src/main/java/org/fenixedu/bennu/struts/portal/RenderersAnnotationProcessor.java
+++ b/bennu-struts/src/main/java/org/fenixedu/bennu/struts/portal/RenderersAnnotationProcessor.java
@@ -73,8 +73,9 @@ public class RenderersAnnotationProcessor implements ServletContainerInitializer
                     LocalizedString description =
                             functionality.descriptionKey().equals(DELEGATE) ? title : BundleUtil.getLocalizedString(bundle,
                                     functionality.descriptionKey());
-                    functionalityClasses.put(type, new Functionality(StrutsPortalBackend.BACKEND_KEY, computePath(type),
-                            functionality.path(), findGroupForFunctionality(type), title, description));
+                    functionalityClasses.put(type,
+                            new Functionality(StrutsPortalBackend.BACKEND_KEY, computePath(type), functionality.path(),
+                                    findGroupForFunctionality(type), title, description, functionality.documentationUrl()));
                 }
                 StrutsApplication application = type.getAnnotation(StrutsApplication.class);
                 if (application != null) {

--- a/bennu-struts/src/main/java/org/fenixedu/bennu/struts/portal/StrutsFunctionality.java
+++ b/bennu-struts/src/main/java/org/fenixedu/bennu/struts/portal/StrutsFunctionality.java
@@ -39,4 +39,5 @@ public @interface StrutsFunctionality {
 
     String accessGroup() default RenderersAnnotationProcessor.DELEGATE;
 
+    String documentationUrl() default "";
 }


### PR DESCRIPTION
### Features:
- New anotation parameter for documentation url's.
 - For backwards compability, default value is an empty string.

### Dependencies
- Depends on FenixEdu/bennu#182 
